### PR TITLE
Change checking TDateTime

### DIFF
--- a/OmniXMLPersistent.pas
+++ b/OmniXMLPersistent.pas
@@ -360,8 +360,7 @@ begin
       tkInteger, tkChar, tkWChar, tkEnumeration, tkSet: WriteOrdProp;
       tkString, tkLString, tkWString {$IFDEF UNICODE}, tkUString {$ENDIF}: WriteStrProp;
       tkFloat:
-        if (PropType = System.TypeInfo(TDateTime)) or (PropType = System.TypeInfo(TTime))
-          or (PropType = System.TypeInfo(TDate)) then
+        if (PropType = System.TypeInfo(TDateTime)) then
             WriteDateTimeProp
         else
           WriteFloatProp;
@@ -726,8 +725,7 @@ begin
       tkInteger, tkChar, tkWChar, tkEnumeration, tkSet: ReadOrdProp;
       tkString, tkLString, tkWString {$IFDEF UNICODE}, tkUString {$ENDIF}: ReadStrProp;
       tkFloat:
-        if (PropType = System.TypeInfo(TDateTime)) or (PropType = System.TypeInfo(TTime))
-          or (PropType = System.TypeInfo(TDate)) then
+        if (PropType = System.TypeInfo(TDateTime)) then
             ReadDateTimeProp
         else
           ReadFloatProp;


### PR DESCRIPTION
In current state module OmniXmlPersistent doesn't compile under Delphi 7 in console applications. Quick investigation revealed:
 * In D7 TDate/TTime are declared in unit Controls which is excluded from uses without "VCL" define.
 * In D7 and D10.3 TDate/TTime are type TDateTime.

I'm suggesting to cut "if statement", because parts checking TTime and TDate are excessive, due to TDate/TTime reference TDateTime.